### PR TITLE
chore: add .env.example files for local docker setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://dummy_user:dummy_password@localhost:5432/dummy_db"
+PORT=3000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Allow example env files so the team knows what variables are needed
+!.env.example


### PR DESCRIPTION
Resolves #17

Added .env.example templates for backend and frontend 
so the team can run Docker locally without sharing real credentials.