### PR TITLE
feat: add cart and cart_items schema migration

### DIFF
--- a/backend/prisma/migrations/20260503161823_add_cart_schema/migration.sql
+++ b/backend/prisma/migrations/20260503161823_add_cart_schema/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "carts" (
+    "id" SERIAL NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "carts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "cart_items" (
+    "id" SERIAL NOT NULL,
+    "cart_id" INTEGER NOT NULL,
+    "variant_id" TEXT NOT NULL,
+    "quantity" SMALLINT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cart_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "carts_user_id_key" ON "carts"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "cart_items_cart_id_variant_id_key" ON "cart_items"("cart_id", "variant_id");
+
+-- AddForeignKey
+ALTER TABLE "carts" ADD CONSTRAINT "carts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_cart_id_fkey" FOREIGN KEY ("cart_id") REFERENCES "carts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_variant_id_fkey" FOREIGN KEY ("variant_id") REFERENCES "product_variants"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   userRoles       UserRole[]
   // Refresh tokens are stored hashed for security.
   refreshTokens   RefreshToken[]
+  cart            Cart?
   ownedBrands     Brand[]
   brandFollowers  BrandFollower[]
   @@map("users")
@@ -248,6 +249,7 @@ model ProductVariant {
   inventory     Inventory?
 
   images  ProductImage[]
+  cartItems CartItem[]
 
   @@map("product_variants")
 
@@ -342,4 +344,40 @@ model Inventory {
   updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   @@map("inventory")
+}
+
+// ─────────────────────────────────────────
+// CART & CART ITEMS
+// Created by: Hamza Baker
+// Created at: 03.05.2026
+// ─────────────────────────────────────────
+
+model Cart {
+  id        Int      @id @default(autoincrement())
+  userId    String   @unique @map("user_id")
+  // One cart per user — enforced by @unique on userId
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt      @map("updated_at") @db.Timestamptz
+
+  items     CartItem[]
+
+  @@map("carts")
+}
+
+model CartItem {
+  id        Int            @id @default(autoincrement())
+  cartId    Int            @map("cart_id")
+  cart      Cart           @relation(fields: [cartId], references: [id], onDelete: Cascade)
+  variantId String         @map("variant_id")
+  // variantId is String (UUID) — matches product_variants.id convention
+  variant   ProductVariant @relation(fields: [variantId], references: [id], onDelete: Cascade)
+
+  quantity  Int      @db.SmallInt
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  // A variant can only appear once per cart
+  @@unique([cartId, variantId])
+  @@map("cart_items")
 }


### PR DESCRIPTION
## Cart Schema Migration

Adds the `carts` and `cart_items` tables to support authenticated persistent carts.

---

### 📁 Files Changed

- `prisma/schema.prisma` — Added `Cart` and `CartItem` models, added relations to `User` and `ProductVariant`
- `prisma/migrations/20260503161823_add_cart_schema/migration.sql` — Generated migration file

---

### 🗒️ Schema Design

```prisma
model Cart {
  id        Int      @id @default(autoincrement())
  userId    String   @unique
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt
}

model CartItem {
  id        Int    @id @default(autoincrement())
  cartId    Int
  variantId String
  quantity  Int
  createdAt DateTime @default(now())

  @@unique([cartId, variantId])
}
```

---

### ✅ Architectural Decisions

| Decision | Why |
|---|---|
| `Int` ID on Cart and CartItem | Cart ID is never exposed on user-facing endpoints — no UUID needed |
| `@unique userId` on Cart | One cart per user — enforced at schema level |
| `variantId` as String (UUID) | FK to `product_variants.id` which is UUID — type must match |
| `@@unique([cartId, variantId])` | A variant can only appear once per cart — enforced at schema level |
| No guest carts | `session_token` excluded — out of scope for this card |

---

### 🧪 Verification

```
✓ Migration applied cleanly
✓ npx prisma migrate deploy — no pending migrations
✓ Seed runs without errors — all existing data intact
```

Resolves #40 