### PR TITLE
feat: add orders and order_items schema migration

### DIFF
--- a/backend/prisma/migrations/20260505122101_add_orders_schema/migration.sql
+++ b/backend/prisma/migrations/20260505122101_add_orders_schema/migration.sql
@@ -1,0 +1,78 @@
+-- CreateTable
+CREATE TABLE "carts" (
+    "id" SERIAL NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "carts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "cart_items" (
+    "id" SERIAL NOT NULL,
+    "cart_id" INTEGER NOT NULL,
+    "variant_id" TEXT NOT NULL,
+    "quantity" SMALLINT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cart_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "orders" (
+    "id" SERIAL NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "order_number" VARCHAR(30) NOT NULL,
+    "status" VARCHAR(50) NOT NULL DEFAULT 'PENDING',
+    "total_amount" DECIMAL(12,2) NOT NULL,
+    "currency" CHAR(3) NOT NULL DEFAULT 'TRY',
+    "payment_reference" VARCHAR(255),
+    "notes" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "orders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "order_items" (
+    "id" SERIAL NOT NULL,
+    "order_id" INTEGER NOT NULL,
+    "variant_id" TEXT NOT NULL,
+    "product_name" VARCHAR(300) NOT NULL,
+    "sku" VARCHAR(100) NOT NULL,
+    "quantity" SMALLINT NOT NULL,
+    "unit_price" DECIMAL(10,2) NOT NULL,
+    "total_price" DECIMAL(12,2) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "carts_user_id_key" ON "carts"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "cart_items_cart_id_variant_id_key" ON "cart_items"("cart_id", "variant_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "orders_order_number_key" ON "orders"("order_number");
+
+-- AddForeignKey
+ALTER TABLE "carts" ADD CONSTRAINT "carts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_cart_id_fkey" FOREIGN KEY ("cart_id") REFERENCES "carts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_variant_id_fkey" FOREIGN KEY ("variant_id") REFERENCES "product_variants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_variant_id_fkey" FOREIGN KEY ("variant_id") REFERENCES "product_variants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260505122101_add_orders_schema/migration.sql
+++ b/backend/prisma/migrations/20260505122101_add_orders_schema/migration.sql
@@ -1,25 +1,4 @@
 -- CreateTable
-CREATE TABLE "carts" (
-    "id" SERIAL NOT NULL,
-    "user_id" TEXT NOT NULL,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL,
-
-    CONSTRAINT "carts_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "cart_items" (
-    "id" SERIAL NOT NULL,
-    "cart_id" INTEGER NOT NULL,
-    "variant_id" TEXT NOT NULL,
-    "quantity" SMALLINT NOT NULL,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "cart_items_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "orders" (
     "id" SERIAL NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -51,22 +30,7 @@ CREATE TABLE "order_items" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "carts_user_id_key" ON "carts"("user_id");
-
--- CreateIndex
-CREATE UNIQUE INDEX "cart_items_cart_id_variant_id_key" ON "cart_items"("cart_id", "variant_id");
-
--- CreateIndex
 CREATE UNIQUE INDEX "orders_order_number_key" ON "orders"("order_number");
-
--- AddForeignKey
-ALTER TABLE "carts" ADD CONSTRAINT "carts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_cart_id_fkey" FOREIGN KEY ("cart_id") REFERENCES "carts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_variant_id_fkey" FOREIGN KEY ("variant_id") REFERENCES "product_variants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "orders" ADD CONSTRAINT "orders_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   // Refresh tokens are stored hashed for security.
   refreshTokens   RefreshToken[]
   cart            Cart?
+  orders          Order[]
   ownedBrands     Brand[]
   brandFollowers  BrandFollower[]
   @@map("users")
@@ -250,6 +251,7 @@ model ProductVariant {
 
   images  ProductImage[]
   cartItems CartItem[]
+  orderItems OrderItem[]
 
   @@map("product_variants")
 
@@ -380,4 +382,53 @@ model CartItem {
   // A variant can only appear once per cart
   @@unique([cartId, variantId])
   @@map("cart_items")
+}
+
+// ─────────────────────────────────────────
+// ORDERS & ORDER ITEMS
+// Created by: Hamza Baker
+// Created at: 05.05.2026
+// ─────────────────────────────────────────
+
+model Order {
+  id               Int      @id @default(autoincrement())
+  userId           String   @map("user_id")
+  // Restrict prevents deleting a user who has order history — financial records must be preserved
+  user             User     @relation(fields: [userId], references: [id], onDelete: Restrict)
+
+  // Human-readable order number for customer-facing display (e.g. ORD-00001)
+  orderNumber      String   @unique @map("order_number") @db.VarChar(30)
+  // Allowed values: PENDING, PAID, CANCELLED, REFUNDED
+  status           String   @default("PENDING") @db.VarChar(50)
+  totalAmount      Decimal  @map("total_amount") @db.Decimal(12, 2)
+  currency         String   @default("TRY") @db.Char(3)
+  // Stores mock payment ID now, real Stripe payment intent ID later
+  paymentReference String?  @map("payment_reference") @db.VarChar(255)
+  notes            String?
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime @updatedAt      @map("updated_at") @db.Timestamptz
+
+  items            OrderItem[]
+
+  @@map("orders")
+}
+
+model OrderItem {
+  id          Int            @id @default(autoincrement())
+  orderId     Int            @map("order_id")
+  order       Order          @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  variantId   String         @map("variant_id")
+  // variantId is String (UUID) — matches product_variants.id convention
+  variant     ProductVariant @relation(fields: [variantId], references: [id])
+
+  // Snapshot of product name and SKU at time of purchase — protects against future changes
+  productName String   @map("product_name") @db.VarChar(300)
+  sku         String   @db.VarChar(100)
+  quantity    Int      @db.SmallInt
+  // Price snapshot at time of purchase — never reference live price
+  unitPrice   Decimal  @map("unit_price")  @db.Decimal(10, 2)
+  totalPrice  Decimal  @map("total_price") @db.Decimal(12, 2)
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@map("order_items")
 }


### PR DESCRIPTION
## Orders Schema Migration

Adds the `orders` and `order_items` tables to support recording customer purchases.

---

### 📁 Files Changed

- `prisma/schema.prisma` — Added `Order` and `OrderItem` models, added relations to `User` and `ProductVariant`
- `prisma/migrations/20260505122101_add_orders_schema/migration.sql` — Generated migration file

---

### 🗒️ Schema Design

```prisma
model Order {
  id               Int      @id @default(autoincrement())
  userId           String
  orderNumber      String   @unique
  status           String   @default("PENDING")
  totalAmount      Decimal
  currency         String   @default("TRY")
  paymentReference String?
  notes            String?
  createdAt        DateTime @default(now())
  updatedAt        DateTime @updatedAt
}

model OrderItem {
  id          Int    @id @default(autoincrement())
  orderId     Int
  variantId   String
  productName String
  sku         String
  quantity    Int
  unitPrice   Decimal
  totalPrice  Decimal
  createdAt   DateTime @default(now())
}
```

---

### ✅ Architectural Decisions

| Decision | Why |
|---|---|
| `Int` ID | Order ID is never exposed on security-sensitive endpoints |
| `onDelete: Restrict` on Order → User | Financial records must never be deleted when a user is deleted |
| `onDelete: Cascade` on OrderItem → Order | If an order is deleted, its items are deleted too — no orphaned records |
| `orderNumber` unique string | Human-readable reference for customer support and tracking |
| `currency` snapshotted | Orders are financial records — currency must be locked at purchase time |
| `productName` + `sku` in OrderItem | Protects order history if product is renamed or deleted later |
| `unitPrice` + `totalPrice` in OrderItem | Price snapshot at purchase time — never references live price |
| No `shipping_address_id` | Shipping schema not yet designed — Phase 3 |
| No `coupon_id` | Coupon schema not yet designed — Phase 3 |
| No `subtotal`/`discount`/`tax` | No coupon or tax logic yet — Phase 3 |

---

### 🔄 Order Status Lifecycle

```
PENDING → PAID → REFUNDED
PENDING → CANCELLED
```

---

### 🧪 Verification

```
✓ Migration applied cleanly
✓ npx prisma migrate deploy — no pending migrations
✓ Seed runs without errors — all existing data intact
```

Resolves #43 