### PR TITLE
feat: add orders API with mock payment service

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { AdminModule } from './admin/admin.module';
 import { CategoriesModule } from './categories/categories.module';
 import { ProductsModule } from './products/products.module';
 import { CartModule } from './cart/cart.module';
+import { OrdersModule } from './orders/orders.module';
 
 /**
  * AuthModule registers all auth routes and makes JWT strategy available.

--- a/backend/src/orders/dto/create-order.dto.ts
+++ b/backend/src/orders/dto/create-order.dto.ts
@@ -1,0 +1,2 @@
+// No fields needed — order is built entirely from the authenticated user's cart
+export class CreateOrderDto {}

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -1,0 +1,38 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('orders')
+@UseGuards(JwtAuthGuard)
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  // Place order from authenticated user's cart
+  @Post()
+  createOrder(@Request() req: { user: { sub: string } }): Promise<object> {
+    return this.ordersService.createOrder(req.user.sub);
+  }
+
+  // Get all orders for authenticated user — newest first
+  @Get()
+  getOrders(@Request() req: { user: { sub: string } }): Promise<object[]> {
+    return this.ordersService.getOrders(req.user.sub);
+  }
+
+  // Get single order detail — throws 404 if not found or belongs to different user
+  @Get(':id')
+  getOrder(
+    @Request() req: { user: { sub: string } },
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<object> {
+    return this.ordersService.getOrder(req.user.sub, id);
+  }
+}

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { OrdersController } from './orders.controller';
+import { PrismaService } from '../prisma.service';
+import { AuthModule } from '../auth/auth.module';
+import { PaymentModule } from '../payment/payment.module';
+
+@Module({
+  imports: [AuthModule, PaymentModule],
+  controllers: [OrdersController],
+  providers: [OrdersService, PrismaService],
+})
+export class OrdersModule {}

--- a/backend/src/orders/orders.service.spec.ts
+++ b/backend/src/orders/orders.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrdersService } from './orders.service';
+import { PrismaService } from '../prisma.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PAYMENT_SERVICE } from '../payment/payment.interface';
+import { Decimal } from '@prisma/client/runtime/library';
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+
+  let mockPrisma: {
+    cart: { findUnique: jest.Mock };
+    order: { findMany: jest.Mock; findUnique: jest.Mock };
+    cartItem: { deleteMany: jest.Mock };
+    $transaction: jest.Mock;
+  };
+
+  let mockPaymentService: {
+    processPayment: jest.Mock;
+  };
+
+  let mockTx: {
+    cart: { findUnique: jest.Mock };
+    order: { create: jest.Mock };
+    cartItem: { deleteMany: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    mockTx = {
+      cart: { findUnique: jest.fn() },
+      order: { create: jest.fn() },
+      cartItem: { deleteMany: jest.fn() },
+    };
+
+    mockPrisma = {
+      cart: { findUnique: jest.fn() },
+      order: { findMany: jest.fn(), findUnique: jest.fn() },
+      cartItem: { deleteMany: jest.fn() },
+      $transaction: jest.fn((cb) => cb(mockTx)),
+    };
+
+    mockPaymentService = {
+      processPayment: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: PAYMENT_SERVICE, useValue: mockPaymentService },
+      ],
+    }).compile();
+
+    service = module.get<OrdersService>(OrdersService);
+  });
+
+  // Helper — builds a mock cart with one item
+  const buildMockCart = () => ({
+    id: 1,
+    userId: 'user-uuid',
+    items: [
+      {
+        id: 1,
+        variantId: 'variant-uuid',
+        quantity: 2,
+        variant: {
+          sku: 'RLG-001',
+          product: {
+            name: 'Rose Lip Gloss',
+            basePrice: new Decimal('25.00'),
+          },
+        },
+      },
+    ],
+  });
+
+  describe('createOrder', () => {
+    it('should throw BadRequestException if cart is empty', async () => {
+      mockTx.cart.findUnique.mockResolvedValue({ id: 1, items: [] });
+
+      await expect(service.createOrder('user-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException if cart does not exist', async () => {
+      mockTx.cart.findUnique.mockResolvedValue(null);
+
+      await expect(service.createOrder('user-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should snapshot price correctly at time of order', async () => {
+      mockTx.cart.findUnique.mockResolvedValue(buildMockCart());
+      mockPaymentService.processPayment.mockResolvedValue({
+        success: true,
+        reference: 'MOCK-ABC123',
+      });
+      mockTx.order.create.mockResolvedValue({
+        id: 1,
+        status: 'PAID',
+        items: [{ unitPrice: new Decimal('25.00'), totalPrice: new Decimal('50.00') }],
+      });
+      mockTx.cartItem.deleteMany.mockResolvedValue({});
+
+      await service.createOrder('user-uuid');
+
+      // Confirm order was created with snapshotted prices
+      expect(mockTx.order.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            totalAmount: new Decimal('50.00'),
+            status: 'PAID',
+          }),
+        }),
+      );
+    });
+
+    it('should create order with status PAID on successful payment', async () => {
+      mockTx.cart.findUnique.mockResolvedValue(buildMockCart());
+      mockPaymentService.processPayment.mockResolvedValue({
+        success: true,
+        reference: 'MOCK-ABC123',
+      });
+      mockTx.order.create.mockResolvedValue({ id: 1, status: 'PAID', items: [] });
+      mockTx.cartItem.deleteMany.mockResolvedValue({});
+
+      const result = await service.createOrder('user-uuid') as any;
+
+      expect(result.status).toBe('PAID');
+    });
+
+    it('should clear cart after successful order', async () => {
+      mockTx.cart.findUnique.mockResolvedValue(buildMockCart());
+      mockPaymentService.processPayment.mockResolvedValue({
+        success: true,
+        reference: 'MOCK-ABC123',
+      });
+      mockTx.order.create.mockResolvedValue({ id: 1, status: 'PAID', items: [] });
+      mockTx.cartItem.deleteMany.mockResolvedValue({});
+
+      await service.createOrder('user-uuid');
+
+      expect(mockTx.cartItem.deleteMany).toHaveBeenCalledWith({
+        where: { cartId: 1 },
+      });
+    });
+
+    it('should throw BadRequestException if payment fails', async () => {
+      mockTx.cart.findUnique.mockResolvedValue(buildMockCart());
+      mockPaymentService.processPayment.mockResolvedValue({
+        success: false,
+        reference: '',
+      });
+
+      await expect(service.createOrder('user-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+
+      // Cart must not be cleared on payment failure
+      expect(mockTx.cartItem.deleteMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOrders', () => {
+    it('should return all orders for the user newest first', async () => {
+      mockPrisma.order.findMany.mockResolvedValue([
+        { id: 2, orderNumber: 'ORD-XYZ', status: 'PAID', totalAmount: new Decimal('50.00') },
+        { id: 1, orderNumber: 'ORD-ABC', status: 'PAID', totalAmount: new Decimal('25.00') },
+      ]);
+
+      const result = await service.getOrders('user-uuid') as any[];
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(2); // newest first
+    });
+  });
+
+  describe('getOrder', () => {
+    it('should throw NotFoundException if order does not exist', async () => {
+      mockPrisma.order.findUnique.mockResolvedValue(null);
+
+      await expect(service.getOrder('user-uuid', 999)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException if order belongs to different user', async () => {
+      mockPrisma.order.findUnique.mockResolvedValue({
+        id: 1,
+        userId: 'other-user-uuid', // different user
+        items: [],
+      });
+
+      await expect(service.getOrder('user-uuid', 1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should return order if it belongs to the user', async () => {
+      mockPrisma.order.findUnique.mockResolvedValue({
+        id: 1,
+        userId: 'user-uuid',
+        status: 'PAID',
+        items: [],
+      });
+
+      const result = await service.getOrder('user-uuid', 1) as any;
+
+      expect(result.id).toBe(1);
+      expect(result.status).toBe('PAID');
+    });
+  });
+});

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -1,0 +1,124 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  Inject,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { IPaymentService, PAYMENT_SERVICE } from '../payment/payment.interface';
+import { Decimal } from '@prisma/client/runtime/library';
+
+@Injectable()
+export class OrdersService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(PAYMENT_SERVICE) private readonly paymentService: IPaymentService,
+  ) {}
+
+  async createOrder(userId: string): Promise<object> {
+    return this.prisma.$transaction(async (tx) => {
+      // Fetch cart and all items with variant pricing
+      const cart = await tx.cart.findUnique({
+        where: { userId },
+        include: {
+          items: {
+            include: {
+              variant: {
+                select: {
+                  sku: true,
+                  product: { select: { name: true, basePrice: true } },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!cart || cart.items.length === 0) {
+        throw new BadRequestException('Cart is empty');
+      }
+
+      // Snapshot prices at time of order — never reference live price after this
+      const orderItems = cart.items.map((item) => ({
+        variantId: item.variantId,
+        productName: item.variant.product.name,
+        sku: item.variant.sku,
+        quantity: item.quantity,
+        unitPrice: item.variant.product.basePrice,
+        totalPrice: item.variant.product.basePrice.mul(item.quantity),
+      }));
+
+      // Calculate total from snapshots
+      const totalAmount = orderItems.reduce(
+        (sum, item) => sum.add(item.totalPrice),
+        new Decimal(0),
+      );
+
+      // Generate unique order number
+      const orderNumber =
+        'ORD-' + Math.random().toString(36).substring(2, 10).toUpperCase();
+
+      // Process payment through abstraction layer
+      const paymentResult = await this.paymentService.processPayment(
+        totalAmount,
+        'TRY',
+        { userId, orderNumber },
+      );
+
+      if (!paymentResult.success) {
+        // Transaction rolls back — cart untouched
+        throw new BadRequestException('Payment failed');
+      }
+
+      // Create order with PAID status
+      const order = await tx.order.create({
+        data: {
+          userId,
+          orderNumber,
+          status: 'PAID',
+          totalAmount,
+          currency: 'TRY',
+          paymentReference: paymentResult.reference,
+          items: {
+            create: orderItems,
+          },
+        },
+        include: { items: true },
+      });
+
+      // Clear cart after successful order
+      await tx.cartItem.deleteMany({ where: { cartId: cart.id } });
+
+      return order;
+    });
+  }
+
+  async getOrders(userId: string): Promise<object[]> {
+    return this.prisma.order.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        totalAmount: true,
+        currency: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  async getOrder(userId: string, orderId: number): Promise<object> {
+    const order = await this.prisma.order.findUnique({
+      where: { id: orderId },
+      include: { items: true },
+    });
+
+    // Throw 404 for both not found and wrong user — never leak other users' orders
+    if (!order || order.userId !== userId) {
+      throw new NotFoundException(`Order with id "${orderId}" not found`);
+    }
+
+    return order;
+  }
+}

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -5,7 +5,8 @@ import {
   Inject,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
-import { IPaymentService, PAYMENT_SERVICE } from '../payment/payment.interface';
+import type { IPaymentService } from '../payment/payment.interface';
+import { PAYMENT_SERVICE } from '../payment/payment.interface';
 import { Decimal } from '@prisma/client/runtime/library';
 
 @Injectable()

--- a/backend/src/payment/mock-payment.service.ts
+++ b/backend/src/payment/mock-payment.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { IPaymentService, PaymentResult } from './payment.interface';
+
+@Injectable()
+export class MockPaymentService implements IPaymentService {
+  async processPayment(
+    amount: Decimal,
+    currency: string,
+    metadata: object,
+  ): Promise<PaymentResult> {
+    // Mock always succeeds — no external calls, no credentials
+    return {
+      success: true,
+      reference: 'MOCK-' + Math.random().toString(36).substring(2, 10).toUpperCase(),
+    };
+  }
+}

--- a/backend/src/payment/mock-payment.service.ts
+++ b/backend/src/payment/mock-payment.service.ts
@@ -12,7 +12,7 @@ export class MockPaymentService implements IPaymentService {
     // Mock always succeeds — no external calls, no credentials
     return {
       success: true,
-      reference: 'MOCK-' + Math.random().toString(36).substring(2, 10).toUpperCase(),
+      reference: 'MOCK-' + Date.now(),
     };
   }
 }

--- a/backend/src/payment/payment.interface.ts
+++ b/backend/src/payment/payment.interface.ts
@@ -1,0 +1,17 @@
+import { Decimal } from '@prisma/client/runtime/library';
+
+export type PaymentResult = {
+  success: boolean;
+  reference: string;
+};
+
+export interface IPaymentService {
+  processPayment(
+    amount: Decimal,
+    currency: string,
+    metadata: object,
+  ): Promise<PaymentResult>;
+}
+
+// Injection token — OrdersService uses this, never the concrete class
+export const PAYMENT_SERVICE = 'PAYMENT_SERVICE';

--- a/backend/src/payment/payment.module.ts
+++ b/backend/src/payment/payment.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MockPaymentService } from './mock-payment.service';
+import { PAYMENT_SERVICE } from './payment.interface';
+
+@Module({
+  providers: [
+    {
+      // Swap this provider to switch from mock to real Stripe — zero other changes needed
+      provide: PAYMENT_SERVICE,
+      useClass: MockPaymentService,
+    },
+  ],
+  exports: [PAYMENT_SERVICE],
+})
+export class PaymentModule {}


### PR DESCRIPTION
## Orders API + Mock Payment Service

Builds the full Orders API so authenticated customers can place orders from their cart, go through a mock payment flow, and receive order confirmation.

---

### 📁 Files Added

**Payment abstraction layer:**
- `src/payment/payment.interface.ts` — `IPaymentService` interface + `PaymentResult` type + `PAYMENT_SERVICE` injection token
- `src/payment/mock-payment.service.ts` — Always returns success, no external calls, no credentials
- `src/payment/payment.module.ts` — Provides `MockPaymentService` under `PAYMENT_SERVICE` token

**Orders:**
- `src/orders/dto/create-order.dto.ts` — Empty DTO, order built entirely from cart
- `src/orders/orders.service.ts` — Full business logic inside single `$transaction`
- `src/orders/orders.controller.ts` — 3 protected routes, userId from JWT only
- `src/orders/orders.module.ts` — Imports PaymentModule and AuthModule
- `src/orders/orders.service.spec.ts` — 10 tests, all passing

**Modified:**
- `src/app.module.ts` — OrdersModule registered

---

### 🔒 Access Control

| Endpoint | Auth | Description |
|---|---|---|
| POST /orders | ✅ JWT | Place order from cart |
| GET /orders | ✅ JWT | Get all orders, newest first |
| GET /orders/:id | ✅ JWT | Get single order detail |

---

### 🏗️ Key Architecture Decisions

**Payment abstraction** — `OrdersService` injects `PAYMENT_SERVICE` token, never the concrete class. Swapping to real Stripe = write `StripePaymentService`, change one provider. Zero order logic changes.

**Single `$transaction`** — Cart fetch, price snapshot, payment, order creation, and cart clear all run atomically. Payment failure rolls everything back, cart stays untouched.

**Price snapshot** — `unitPrice` is taken from `variant.product.basePrice` at the moment of order creation. Live price is never referenced after this point.

**Security** — `getOrder` throws 404 for both not-found and wrong-user cases. Order existence is never leaked to other users.

**orderNumber** — Generated as `ORD-` + random 8-char string. Unique and human-readable for customer support.

---

### 🧪 Tests

```
PASS src/orders/orders.service.spec.ts
  ✓ should throw BadRequestException if cart is empty
  ✓ should throw BadRequestException if cart does not exist
  ✓ should snapshot price correctly at time of order
  ✓ should create order with status PAID on successful payment
  ✓ should clear cart after successful order
  ✓ should throw BadRequestException if payment fails
  ✓ should return all orders for the user newest first
  ✓ should throw NotFoundException if order does not exist
  ✓ should throw NotFoundException if order belongs to different user
  ✓ should return order if it belongs to the user

All previous tests still pass — 69/69 total ✅
```

Resolves #44 

أعطينا الضوء الأخضر خيو @Zigzag2Z 