### PR TITLE
feat: add admin orders API with status lifecycle management

### DIFF
--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,18 +1,19 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaService } from '../prisma.service';
 import { AdminController } from './admin.controller';
+import { AdminOrdersController } from './orders/admin-orders.controller';
+import { AdminOrdersService } from './orders/admin-orders.service';
 
 /**
- * JwtModule is imported here so JwtAuthGuard can access
- * JwtService via Dependency Injection within this module.
+ * AuthModule is imported (instead of registering JwtModule directly) because
+ * it exports JwtModule, JwtAuthGuard, and RolesGuard. That gives every
+ * controller here the JWT verification + role checking the guards need,
+ * in one line, without re-registering JwtService.
  */
 @Module({
-  imports: [
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: '7d' },
-    }),
-  ],
-  controllers: [AdminController],
+  imports: [AuthModule],
+  controllers: [AdminController, AdminOrdersController],
+  providers: [AdminOrdersService, PrismaService],
 })
 export class AdminModule {}

--- a/backend/src/admin/orders/admin-orders.controller.ts
+++ b/backend/src/admin/orders/admin-orders.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Param,
+  Query,
+  Body,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminOrdersService } from './admin-orders.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { GetOrdersQueryDto } from './dto/get-orders-query.dto';
+import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+
+// Every route here is admin-only. JwtAuthGuard verifies the token first,
+// then RolesGuard checks the role. @Roles('SUPER_ADMIN') sets the bar.
+@Controller('admin/orders')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('SUPER_ADMIN')
+export class AdminOrdersController {
+  constructor(private readonly adminOrdersService: AdminOrdersService) {}
+
+  // GET /admin/orders  (optionally ?status=PAID)
+  // The query DTO validates status before we get here.
+  @Get()
+  getAllOrders(@Query() query: GetOrdersQueryDto): Promise<object[]> {
+    return this.adminOrdersService.getAllOrders(query.status);
+  }
+
+  // GET /admin/orders/:id
+  // ParseIntPipe turns the URL text "12" into the number 12, matching
+  // the Order model's Int id. Non-numeric ids get a 400 automatically.
+  @Get(':id')
+  getOrderById(@Param('id', ParseIntPipe) id: number): Promise<object> {
+    return this.adminOrdersService.getOrderById(id);
+  }
+
+  // PATCH /admin/orders/:id/status
+  // UpdateOrderStatusDto validates the body's status field.
+  @Patch(':id/status')
+  updateOrderStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateOrderStatusDto,
+  ): Promise<object> {
+    return this.adminOrdersService.updateOrderStatus(id, dto.status);
+  }
+}

--- a/backend/src/admin/orders/admin-orders.service.spec.ts
+++ b/backend/src/admin/orders/admin-orders.service.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminOrdersService } from './admin-orders.service';
+import { PrismaService } from '../../prisma.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+
+describe('AdminOrdersService', () => {
+  let service: AdminOrdersService;
+
+  let mockPrisma: {
+    order: {
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+    };
+  };
+
+  beforeEach(async () => {
+    mockPrisma = {
+      order: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminOrdersService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<AdminOrdersService>(AdminOrdersService);
+  });
+
+  describe('getAllOrders', () => {
+    it('should return all orders newest first', async () => {
+      mockPrisma.order.findMany.mockResolvedValue([
+        { id: 2, status: 'PAID', totalAmount: new Decimal('50.00') },
+        { id: 1, status: 'SHIPPED', totalAmount: new Decimal('25.00') },
+      ]);
+
+      const result = (await service.getAllOrders()) as any[];
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(2); // newest first
+      // No status filter passed → where should be undefined (return all)
+      expect(mockPrisma.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: undefined,
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+    });
+
+    it('should filter by status when one is provided', async () => {
+      mockPrisma.order.findMany.mockResolvedValue([
+        { id: 3, status: 'PAID', totalAmount: new Decimal('99.00') },
+      ]);
+
+      await service.getAllOrders('PAID');
+
+      expect(mockPrisma.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: 'PAID' },
+        }),
+      );
+    });
+  });
+
+  describe('getOrderById', () => {
+    it('should return the order with its items', async () => {
+      mockPrisma.order.findUnique.mockResolvedValue({
+        id: 1,
+        status: 'PAID',
+        items: [{ id: 1, productName: 'Rose Lip Gloss', quantity: 2 }],
+      });
+
+      const result = (await service.getOrderById(1)) as any;
+
+      expect(result.id).toBe(1);
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('should throw NotFoundException for a non-existent order', async () => {
+      mockPrisma.order.findUnique.mockResolvedValue(null);
+
+      await expect(service.getOrderById(999)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateOrderStatus', () => {
+    it('should update status when the transition is valid', async () => {
+      // PAID → PROCESSING is allowed
+      mockPrisma.order.findUnique.mockResolvedValue({ id: 1, status: 'PAID' });
+      mockPrisma.order.update.mockResolvedValue({
+        id: 1,
+        status: 'PROCESSING',
+        items: [],
+      });
+
+      const result = (await service.updateOrderStatus(1, 'PROCESSING')) as any;
+
+      expect(result.status).toBe('PROCESSING');
+      expect(mockPrisma.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          data: { status: 'PROCESSING' },
+        }),
+      );
+    });
+
+    it('should throw BadRequestException for an invalid transition', async () => {
+      // PAID → SHIPPED is NOT allowed
+      mockPrisma.order.findUnique.mockResolvedValue({ id: 1, status: 'PAID' });
+
+      await expect(service.updateOrderStatus(1, 'SHIPPED')).rejects.toThrow(
+        BadRequestException,
+      );
+      // Must not attempt the update on a rejected transition
+      expect(mockPrisma.order.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when the order is in a final state', async () => {
+      // DELIVERED has no allowed next states
+      mockPrisma.order.findUnique.mockResolvedValue({
+        id: 1,
+        status: 'DELIVERED',
+      });
+
+      await expect(service.updateOrderStatus(1, 'REFUNDED')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockPrisma.order.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException for a non-existent order', async () => {
+      mockPrisma.order.findUnique.mockResolvedValue(null);
+
+      await expect(service.updateOrderStatus(999, 'PROCESSING')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/admin/orders/admin-orders.service.ts
+++ b/backend/src/admin/orders/admin-orders.service.ts
@@ -1,0 +1,92 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma.service';
+import { OrderStatus } from './dto/update-order-status.dto';
+
+// The transition map IS the business rule, written as data instead of
+// if/else branches. Each key is a current status; the array is every
+// status it is allowed to move to. Final states map to an empty array.
+// Record<OrderStatus, OrderStatus[]> forces us to list all six statuses —
+// if someone adds a new status to the DTO later, TypeScript will error
+// here until they decide its transitions. That is the safety we want.
+const TRANSITION_MAP: Record<OrderStatus, OrderStatus[]> = {
+  PAID: ['PROCESSING', 'CANCELLED', 'REFUNDED'],
+  PROCESSING: ['SHIPPED', 'CANCELLED', 'REFUNDED'],
+  SHIPPED: ['DELIVERED', 'REFUNDED'],
+  DELIVERED: [],
+  CANCELLED: [],
+  REFUNDED: [],
+};
+
+@Injectable()
+export class AdminOrdersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // GET /admin/orders — every order from every user, newest first.
+  // If a status filter is passed, narrow to that status; otherwise return all.
+  async getAllOrders(status?: OrderStatus): Promise<object[]> {
+    return this.prisma.order.findMany({
+      where: status ? { status } : undefined,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        totalAmount: true,
+        currency: true,
+        userId: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  // GET /admin/orders/:id — one order with its line items.
+  // No userId check: an admin is allowed to see any user's order.
+  async getOrderById(id: number): Promise<object> {
+    const order = await this.prisma.order.findUnique({
+      where: { id },
+      include: { items: true },
+    });
+
+    if (!order) {
+      throw new NotFoundException(`Order with id "${id}" not found`);
+    }
+
+    return order;
+  }
+
+  // PATCH /admin/orders/:id/status — move an order to a new status,
+  // but only if the transition map allows it.
+  async updateOrderStatus(id: number, newStatus: OrderStatus): Promise<object> {
+    const order = await this.prisma.order.findUnique({ where: { id } });
+
+    if (!order) {
+      throw new NotFoundException(`Order with id "${id}" not found`);
+    }
+
+    const allowedNext = TRANSITION_MAP[order.status as OrderStatus];
+
+    // No entry, or an empty array, means there is nowhere valid to go.
+    if (!allowedNext || allowedNext.length === 0) {
+      throw new BadRequestException(
+        `Cannot change status of an order in final state ${order.status}.`,
+      );
+    }
+
+    if (!allowedNext.includes(newStatus)) {
+      throw new BadRequestException(
+        `Cannot transition from ${order.status} to ${newStatus}. ` +
+          `Valid next states: ${allowedNext.join(', ')}`,
+      );
+    }
+
+    return this.prisma.order.update({
+      where: { id },
+      data: { status: newStatus },
+      include: { items: true },
+    });
+  }
+}


### PR DESCRIPTION
Resolves #59 

## What this does
Adds the admin-facing Orders API so SUPER_ADMIN users can view all orders
across every user, filter by status, and move orders through the fulfillment
lifecycle with validated status transitions.

## Endpoints
- `GET /admin/orders` — all orders, newest first, optional `?status=` filter
- `GET /admin/orders/:id` — single order with its line items (admin can view any user's order)
- `PATCH /admin/orders/:id/status` — transition an order to a new status

All three are protected by `JwtAuthGuard` + `RolesGuard` and restricted to `SUPER_ADMIN`.

## How status transitions work
Valid transitions are defined as a constant map (`Record<OrderStatus, OrderStatus[]>`),
not hardcoded conditionals. Any move not in the map throws `400 Bad Request` with a
message listing the valid next states. Final states (DELIVERED, CANCELLED, REFUNDED)
allow no further transitions.

| From       | Allowed next states              |
|------------|----------------------------------|
| PAID       | PROCESSING, CANCELLED, REFUNDED  |
| PROCESSING | SHIPPED, CANCELLED, REFUNDED     |
| SHIPPED    | DELIVERED, REFUNDED              |

## Files changed
- `admin/orders/admin-orders.service.ts` (new) — business logic + transition map
- `admin/orders/admin-orders.controller.ts` (new) — routes + guards
- `admin/orders/dto/get-orders-query.dto.ts` (new) — validates the `?status=` filter
- `admin/orders/admin-orders.service.spec.ts` (new) — 8 unit tests
- `admin/admin.module.ts` (edited) — registered new controller/service; swapped direct
  `JwtModule.register` for `AuthModule` import (reuses exported guards)

## Notes for reviewer
- Reused the existing `UpdateOrderStatusDto` / `ORDER_STATUSES` rather than duplicating.
- Added one DTO beyond the issue's Step 4 (`GetOrdersQueryDto`) so the approved
  contract's "invalid ?status= returns 400" promise is enforced at the edge.
- No DB migration — `status` is already VARCHAR(50).
- Did not touch customer-facing orders, frontend, or migrations (per scope boundary).

## Testing
- `npm run build` — passes
- `npm run test` — 59/59 pass (8 new, all pre-existing still green)

@Almohajer00 